### PR TITLE
Fix for the download bug

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
 - name: REDIS_EXPORTER | Download package
   get_url:
     url: "{{ redis_exporter_url }}"
-    dest: /tmp
+    dest: "/tmp/{{ redis_exporter_package }}"
   when: 'redis_exporter_force_reinstall or redis_exporter_check|failed or "Redis Metrics Exporter v{{ redis_exporter_version }}" not in redis_exporter_check.stderr'
 
 - name: REDIS_EXPORTER | Extract downloaded package


### PR DESCRIPTION
Now, if not given the full path (/tmp/foo.tar.gz), the `get_url` task will use a UUID for the filename (/tmp/ff77ff24-1264-11e7-835e-8d427dffb60b).
This leaded to the `unarchive` task to fail, since it uses the full path.
This commit fixes the bug.