### PR TITLE
add variable for redis-exporter listen IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prometheus_redis_exporter-role/tree/develop)
 
+- add default variable `redis_exporter_ip` to set listen ip of redis-exporter. Defaults to 0.0.0.0
+
 ## [1.0.2](https://github.com/idealista/prometheus_redis_exporter-role/tree/1.0.2) (2018-01-02)
 [Full Changelog](https://github.com/idealista/prometheus_redis_exporter-role/compare/1.0.1...1.0.2)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ redis_exporter_bin_path: "{{ redis_exporter_root_path }}/bin"
 
 # Flags (https://github.com/oliver006/redis_exporter#flags)
 redis_exporter_port: 9121
+redis_exporter_ip: 0.0.0.0
 redis_exporter_debug: false
 redis_exporter_log_format: txt #(txt | json)
 redis_exporter_check_keys: ""
@@ -42,5 +43,5 @@ redis_exporter_options:
   - "{{ redis_exporter_redis_password | ternary('redis.password ' + redis_exporter_redis_password, '') }}"
   - "redis.alias {{ redis_exporter_redis_alias }}"
   - "namespace {{ redis_exporter_redis_namespace }}"
-  - "web.listen-address :{{ redis_exporter_port }}"
+  - "web.listen-address {{ redis_exporter_ip }}:{{ redis_exporter_port }}"
   - "web.telemetry-path /{{ redis_exporter_web_telemetry_path }}"


### PR DESCRIPTION
### Description of the Change

Add default variable for exporter listen IP. It is set to 0.0.0.0


### Benefits

You can set listen IP of the redis-exporter. For example in my case I want it to listen on 127.0.0.1 only.

### Possible Drawbacks

Nothing changes.

### Applicable Issues

Nothing.
